### PR TITLE
ステップ2 - Aルール実装の修正

### DIFF
--- a/src/lib/BlackjackGame.php
+++ b/src/lib/BlackjackGame.php
@@ -206,7 +206,3 @@ class BlackjackGame
         return $stdin;
     }
 }
-
-/*
-php lib/Main.php
-*/

--- a/src/lib/Deck.php
+++ b/src/lib/Deck.php
@@ -7,11 +7,6 @@ require_once __DIR__ . ('/Card.php');
 class Deck
 {
     private const SUITS = ['ハート', 'ダイヤ', 'スペード', 'クラブ'];
-
-    /**
-     * ここを修正
-     * Aのスコアを11に変更
-     */
     private const CARD_NUM_AND_SCORES = [
         ['num' => 'A',  'score' => 11],
         ['num' => '2',  'score' => 2],

--- a/src/lib/Player.php
+++ b/src/lib/Player.php
@@ -6,20 +6,30 @@ class Player
 {
     /**
      * @var Card[] $playerCards
-     * @var int $playerTotalScore
+     * @var int    $playerTotalScore
+     * @var int    $aceReductionCount
      */
     private array $playerCards;
     private int $playerTotalScore;
 
+    /**
+     * ここを追加
+     */
+    private int $aceReductionCount;
+
+    /**
+     * ここを追加
+     */
     public function __construct()
     {
         // 初期化処理
         $this->playerCards = [];
         $this->playerTotalScore = 0;
+        $this->aceReductionCount = 0;
     }
 
     /**
-     * デッキからカードを引いて合計点を更新し、持ち札に加える
+     * デッキからカードを引いて持ち札に加え、合計点を更新する
      *
      * @param Deck $deck
      * @param int $drawNum
@@ -29,11 +39,11 @@ class Player
     {
         $drawnCards = $deck->drawCards($drawNum);
 
-        // 合計点を更新する
-        $this->playerTotalScore = $this->updateTotalScore($drawnCards);
-
         // 引いたカードを持ち札に加える
         $this->playerCards = array_merge($this->playerCards, $drawnCards);
+
+        // 合計点を更新する
+        $this->playerTotalScore = $this->updateTotalScore($drawnCards);
 
         return $this->playerCards;
     }
@@ -49,10 +59,6 @@ class Player
     }
 
     /**
-     * ここを修正
-     * Aの得点を減算して調整するロジックを追加
-     */
-    /**
      * プレイヤーの合計点を更新
      *
      * @param Card[] $drawnCards
@@ -60,31 +66,57 @@ class Player
      */
     private function updateTotalScore(array $drawnCards): int
     {
+        // 引いたカードをそれぞれ合計点に合算する
         foreach ($drawnCards as $drawnCard) {
             $this->playerTotalScore += $drawnCard->getScore();
         }
 
-        // 合計21を超える場合、Aの得点を減算して調整
-        if ($this->playerTotalScore > 21) {
-            $this->reduceScoreWithAce($drawnCards);
+        // 合計21を超え、Aがあれば得点を減算して調整
+        if ($this->playerTotalScore > 21 && $this->hasAce()) {
+            $this->reduceScoreWithAce();
         }
 
         return $this->playerTotalScore;
     }
 
     /**
-     * ここを追加
-     * 合計21を超える場合、Aの得点を11から1へと減算する
+     * $playerCardsにAが含まれるかを調べる
      *
-     * @param Card[] $drawnCards
+     * @return bool
+     */
+    private function hasAce(): bool
+    {
+        foreach ($this->playerCards as $playerCard) {
+            if ($playerCard->getNumber() == 'A') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Aの得点を11から1へと減算する
+     *
      * @return void
      */
-    private function reduceScoreWithAce(array $drawnCards): void
+    private function reduceScoreWithAce(): void
     {
-        foreach ($drawnCards as $drawnCard) {
-            if ($drawnCard->getNumber() === 'A' && $this->playerTotalScore > 21) {
-                $this->playerTotalScore -= 10;
+        // Aの出現回数を計算
+        $aceCount = 0;
+        foreach ($this->playerCards as $playerCard) {
+            if ($playerCard->getNumber() == 'A') {
+                $aceCount++;
             }
+        }
+
+        // Aの出現回数以上に減算しないように条件を設定
+        while ($this->playerTotalScore > 21 && $aceCount > $this->aceReductionCount) {
+            // Aの得点分を減算
+            $this->playerTotalScore -= 10;
+
+            // Aによる減算回数をカウント
+            $this->aceReductionCount++;
         }
     }
 }

--- a/src/tests/DealerTest.php
+++ b/src/tests/DealerTest.php
@@ -33,80 +33,106 @@ final class DealerTest extends TestCase
      */
     public function testDrawCardsGetTotalScore(): void
     {
-        // テストA, A
-        $dealer = new Dealer();
-        $deckMock = $this->getMockBuilder(Deck::class)
-            ->disableOriginalConstructor()
+        // テスト1 [A, A]
+        $dealer1 = new Dealer();
+
+        $deckMock1 = $this->getMockBuilder(Deck::class)
             ->getMock();
-        $deckMock->method('drawCards')
-            ->willReturn([
-                new Card('ハート', 'A', 11),
-                new Card('クラブ', 'A', 11)
-            ]);
+        $deckMock1->method('drawCards')
+            ->willReturn([new Card('ハート', 'A', 11), new Card('クラブ', 'A', 11)]);
 
-        // プレイヤーの手札に引かれたカードが正しく追加されているか
-        $dealerCards = $dealer->drawCards($deckMock, 2);
-        $this->assertSame(2, count($dealerCards));
-        // プレイヤーの合計得点が正しく更新されているか
-        $this->assertSame(12, $dealer->getTotalScore());
+        // ディーラーの合計得点が正しく更新されているか
+        $dealer1->drawCards($deckMock1, 2);
+        $this->assertSame(12, $dealer1->getTotalScore());
 
 
-        // テストA, K
+        // テスト2 [A, K]
         $dealer2 = new Dealer();
+
         $deckMock2 = $this->getMockBuilder(Deck::class)
-            ->disableOriginalConstructor()
             ->getMock();
         $deckMock2->method('drawCards')
-            ->willReturn([
-                new Card('ハート', 'A', 11),
-                new Card('クラブ', 'K', 10),
+            ->willReturn([new Card('ハート', 'A', 11), new Card('クラブ', 'K', 10)]);
 
-            ]);
-
-        // プレイヤーの手札に引かれたカードが正しく追加されているか
-        $dealerCards2 = $dealer2->drawCards($deckMock2, 2);
-        $this->assertSame(2, count($dealerCards2));
-        // プレイヤーの合計得点が正しく更新されているか
+        // ディーラーの合計得点が正しく更新されているか
+        $dealer2->drawCards($deckMock2, 2);
         $this->assertSame(21, $dealer2->getTotalScore());
 
 
-        // テスト2, A, A
+        // テスト3 [2, A, A]
         $dealer3 = new Dealer();
-        $deckMock2 = $this->getMockBuilder(Deck::class)
-            ->disableOriginalConstructor()
+
+        $deckMock3_1 = $this->getMockBuilder(Deck::class)
             ->getMock();
-        $deckMock2->method('drawCards')
-            ->willReturn([
-                new Card('スペード', '2', 2),
-                new Card('ハート', 'A', 11),
-                new Card('クラブ', 'A', 11),
+        $deckMock3_1->method('drawCards')
+            ->willReturn([new Card('スペード', '2', 2), new Card('ハート', 'A', 11)]);
 
-            ]);
+        $deckMock3_2 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock3_2->method('drawCards')
+            ->willReturn([new Card('クラブ', 'A', 11)]);
 
-        // プレイヤーの手札に引かれたカードが正しく追加されているか
-        $dealerCards3 = $dealer3->drawCards($deckMock2, 3);
-        $this->assertSame(3, count($dealerCards3));
-        // プレイヤーの合計得点が正しく更新されているか
+        // ディーラーの合計得点が正しく更新されているか
+        $dealer3->drawCards($deckMock3_1, 2);
+        $dealer3->drawCards($deckMock3_2, 1);
         $this->assertSame(14, $dealer3->getTotalScore());
 
 
-        // テストA, 2, 8, A
+        // テスト4 [A, 2, 8, A]
         $dealer4 = new Dealer();
-        $deckMock4 = $this->getMockBuilder(Deck::class)
-            ->disableOriginalConstructor()
+
+        $deckMock4_1 = $this->getMockBuilder(Deck::class)
             ->getMock();
-        $deckMock4->method('drawCards')
+        $deckMock4_1->method('drawCards')
+            ->willReturn([new Card('スペード', 'A', 11), new Card('スペード', '2', 2)]);
+
+        $deckMock4_2 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock4_2->method('drawCards')
             ->willReturn([
-                new Card('スペード', 'A', 11),
-                new Card('スペード', '2', 2),
-                new Card('ハート', '8', 8),
-                new Card('クラブ', 'A', 11),
+                new Card('ハート', '8', 8)
             ]);
 
-        // プレイヤーの手札に引かれたカードが正しく追加されているか
-        $dealerCards4 = $dealer4->drawCards($deckMock4, 4);
-        $this->assertSame(4, count($dealerCards4));
-        // プレイヤーの合計得点が正しく更新されているか
+        $deckMock4_3 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock4_3->method('drawCards')
+            ->willReturn([
+                new Card('クラブ', 'A', 11)
+            ]);
+
+        // ディーラーの合計得点が正しく更新されているか
+        $dealer4->drawCards($deckMock4_1, 2);
+        $dealer4->drawCards($deckMock4_2, 1);
+        $dealer4->drawCards($deckMock4_3, 1);
         $this->assertSame(12, $dealer4->getTotalScore());
+
+
+        // テスト5 [A, K, A, J]
+        $dealer5 = new Dealer();
+
+        $deckMock5_1 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock5_1->method('drawCards')
+            ->willReturn([new Card('スペード', 'A', 11), new Card('スペード', 'K', 10)]);
+
+        $deckMock5_2 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock5_2->method('drawCards')
+            ->willReturn([
+                new Card('ハート', 'A', 11)
+            ]);
+
+        $deckMock5_3 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock5_3->method('drawCards')
+            ->willReturn([
+                new Card('クラブ', 'J', 10)
+            ]);
+
+        // ディーラーの合計得点が正しく更新されているか
+        $dealer5->drawCards($deckMock5_1, 2);
+        $dealer5->drawCards($deckMock5_2, 1);
+        $dealer5->drawCards($deckMock5_3, 1);
+        $this->assertSame(22, $dealer5->getTotalScore());
     }
 }

--- a/src/tests/PlayerTest.php
+++ b/src/tests/PlayerTest.php
@@ -29,84 +29,155 @@ final class PlayerTest extends TestCase
     }
 
     /**
-     * ここを追加
+     * ここを修正
      */
     public function testDrawCardsGetTotalScore(): void
     {
-        // テストA, A
-        $player = new Player();
-        $deckMock = $this->getMockBuilder(Deck::class)
-            ->disableOriginalConstructor()
+        // テスト1 [A, A]
+        $player1 = new Player();
+
+        $deckMock1 = $this->getMockBuilder(Deck::class)
             ->getMock();
-        $deckMock->method('drawCards')
-            ->willReturn([
-                new Card('ハート', 'A', 11),
-                new Card('クラブ', 'A', 11)
-            ]);
+        $deckMock1->method('drawCards')
+            ->willReturn([new Card('ハート', 'A', 11), new Card('クラブ', 'A', 11)]);
 
-        // プレイヤーの手札に引かれたカードが正しく追加されているか
-        $playerCards = $player->drawCards($deckMock, 2);
-        $this->assertSame(2, count($playerCards));
         // プレイヤーの合計得点が正しく更新されているか
-        $this->assertSame(12, $player->getTotalScore());
+        $player1->drawCards($deckMock1, 2);
+        $this->assertSame(12, $player1->getTotalScore());
 
 
-        // テストA, K
+        // テスト2 [A, K]
         $player2 = new Player();
+
         $deckMock2 = $this->getMockBuilder(Deck::class)
-            ->disableOriginalConstructor()
             ->getMock();
         $deckMock2->method('drawCards')
-            ->willReturn([
-                new Card('ハート', 'A', 11),
-                new Card('クラブ', 'K', 10),
+            ->willReturn([new Card('ハート', 'A', 11), new Card('クラブ', 'K', 10)]);
 
-            ]);
-
-        // プレイヤーの手札に引かれたカードが正しく追加されているか
-        $playerCards2 = $player2->drawCards($deckMock2, 2);
-        $this->assertSame(2, count($playerCards2));
         // プレイヤーの合計得点が正しく更新されているか
+        $player2->drawCards($deckMock2, 2);
         $this->assertSame(21, $player2->getTotalScore());
 
 
-        // テスト2, A, A
+        // テスト3 [2, A, A]
         $player3 = new Player();
-        $deckMock2 = $this->getMockBuilder(Deck::class)
-            ->disableOriginalConstructor()
+
+        $deckMock3_1 = $this->getMockBuilder(Deck::class)
             ->getMock();
-        $deckMock2->method('drawCards')
-            ->willReturn([
-                new Card('スペード', '2', 2),
-                new Card('ハート', 'A', 11),
-                new Card('クラブ', 'A', 11),
+        $deckMock3_1->method('drawCards')
+            ->willReturn([new Card('スペード', '2', 2), new Card('ハート', 'A', 11)]);
 
-            ]);
+        $deckMock3_2 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock3_2->method('drawCards')
+            ->willReturn([new Card('クラブ', 'A', 11)]);
 
-        // プレイヤーの手札に引かれたカードが正しく追加されているか
-        $playerCards3 = $player3->drawCards($deckMock2, 3);
-        $this->assertSame(3, count($playerCards3));
         // プレイヤーの合計得点が正しく更新されているか
+        $player3->drawCards($deckMock3_1, 2);
+        $player3->drawCards($deckMock3_2, 1);
         $this->assertSame(14, $player3->getTotalScore());
 
 
-        // テストA, 2, 8, A
+        // テスト4 [A, 2, 8, A]
         $player4 = new Player();
-        $deckMock4 = $this->getMockBuilder(Deck::class)
-            ->disableOriginalConstructor()
+
+        $deckMock4_1 = $this->getMockBuilder(Deck::class)
             ->getMock();
-        $deckMock4->method('drawCards')
+        $deckMock4_1->method('drawCards')
+            ->willReturn([new Card('スペード', 'A', 11), new Card('スペード', '2', 2)]);
+
+        $deckMock4_2 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock4_2->method('drawCards')
             ->willReturn([
-                new Card('スペード', 'A', 11),
-                new Card('スペード', '2', 2),
-                new Card('ハート', '8', 8),
-                new Card('クラブ', 'A', 11),
+                new Card('ハート', '8', 8)
             ]);
 
-        // プレイヤーの手札に引かれたカードが正しく追加されているか
-        $playerCards4 = $player4->drawCards($deckMock4, 4);
-        $this->assertSame(4, count($playerCards4));
+        $deckMock4_3 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock4_3->method('drawCards')
+            ->willReturn([
+                new Card('クラブ', 'A', 11)
+            ]);
+
         // プレイヤーの合計得点が正しく更新されているか
+        $player4->drawCards($deckMock4_1, 2);
+        $player4->drawCards($deckMock4_2, 1);
+        $player4->drawCards($deckMock4_3, 1);
         $this->assertSame(12, $player4->getTotalScore());
+
+
+        // テスト5 [A, K, A, J]
+        $player5 = new Player();
+
+        $deckMock5_1 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock5_1->method('drawCards')
+            ->willReturn([new Card('スペード', 'A', 11), new Card('スペード', 'K', 10)]);
+
+        $deckMock5_2 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock5_2->method('drawCards')
+            ->willReturn([
+                new Card('ハート', 'A', 11)
+            ]);
+
+        $deckMock5_3 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock5_3->method('drawCards')
+            ->willReturn([
+                new Card('クラブ', 'J', 10)
+            ]);
+
+        // プレイヤーの合計得点が正しく更新されているか
+        $player5->drawCards($deckMock5_1, 2);
+        $player5->drawCards($deckMock5_2, 1);
+        $player5->drawCards($deckMock5_3, 1);
+        $this->assertSame(22, $player5->getTotalScore());
+
+
+        // テスト6 [A, A, A, A, 8, K]
+        $player6 = new Player();
+
+        $deckMock6_1 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock6_1->method('drawCards')
+            ->willReturn([new Card('スペード', 'A', 11), new Card('ハート', 'A', 11)]);
+
+        $deckMock6_2 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock6_2->method('drawCards')
+            ->willReturn([
+                new Card('クラブ', 'A', 11)
+            ]);
+
+        $deckMock6_3 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock6_3->method('drawCards')
+            ->willReturn([
+                new Card('ダイヤ', 'A', 11)
+            ]);
+
+        $deckMock6_4 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock6_4->method('drawCards')
+            ->willReturn([
+                new Card('ダイヤ', '8', 8)
+            ]);
+
+        $deckMock6_5 = $this->getMockBuilder(Deck::class)
+            ->getMock();
+        $deckMock6_5->method('drawCards')
+            ->willReturn([
+                new Card('クラブ', 'K', 10)
+            ]);
+
+        // プレイヤーの合計得点が正しく更新されているか
+        $player6->drawCards($deckMock6_1, 2);
+        $player6->drawCards($deckMock6_2, 1);
+        $player6->drawCards($deckMock6_3, 1);
+        $player6->drawCards($deckMock6_4, 1);
+        $player6->drawCards($deckMock6_5, 1);
+        $this->assertSame(22, $player6->getTotalScore());
     }
 }


### PR DESCRIPTION
## 実装(Playerクラス. Dealerクラス)
- 変更前
カードを引いて得点が21を超えた場合、持ち札にAがあれば-10点されてしまっていた。
（バーストせずゲームが終わらない）

- 変更後
Aを引いた数を限度として合計点を調整（-10点）するように修正した。  

## テスト
- 変更前
最終の持ち札から一気に合計点を計算する仕様になっており、Aによる点数の移り変わりをテストできていなかった。
（カードを2枚引いて, 次に1枚引いて..という作業を表せていなかった。）
  
- 変更後
最初に2枚のカードを引き、以降は1枚ずつカードを引くという流れに修正した。

close #12 